### PR TITLE
Fix compilation error due to ambiguous DynamicType

### DIFF
--- a/src/Participant.cpp
+++ b/src/Participant.cpp
@@ -275,7 +275,7 @@ const fastrtps::types::DynamicType* Participant::get_dynamic_type(
         return nullptr;
     }
 
-    return static_cast<const DynamicType*>(it->second.GetDynamicType().get());
+    return static_cast<const fastrtps::types::DynamicType*>(it->second.GetDynamicType().get());
 }
 
 const std::string& Participant::get_topic_type(


### PR DESCRIPTION
 Building the plugin with the latest version of Fast-DDS installed fails with the following error:
```
code/src/fastdds-sh/src/Participant.cpp: In member function 'const eprosima::fastrtps::types::DynamicType* eprosima::is::sh::fastdds::Participant::get_dynamic_type(const string&) const':
/code/src/fastdds-sh/src/Participant.cpp:278:30: error: ISO C++ forbids declaration of 'type name' with no type [-fpermissive]
     return static_cast<const DynamicType*>(it->second.GetDynamicType().get());
                              ^~~~~~~~~~~
/code/src/fastdds-sh/src/Participant.cpp:278:30: error: expected '>' before 'DynamicType'
/code/src/fastdds-sh/src/Participant.cpp:278:30: error: expected '(' before 'DynamicType'
/code/src/fastdds-sh/src/Participant.cpp:278:30: error: reference to 'DynamicType' is ambiguous
In file included from /usr/local/include/fastdds/dds/topic/IContentFilter.hpp:31:0,
                 from /usr/local/include/fastdds/dds/topic/IContentFilterFactory.hpp:25,
                 from /usr/local/include/fastdds/dds/domain/DomainParticipant.hpp:34,
                 from /code/src/fastdds-sh/src/Participant.hpp:23,
                 from /code/src/fastdds-sh/src/Participant.cpp:18:
/usr/local/include/fastrtps/types/TypeDescriptor.h:23:7: note: candidates are: class DynamicType
 class DynamicType;
       ^~~~~~~~~~~
In file included from /code/src/fastdds-sh/src/Participant.hpp:26:0,
                 from /code/src/fastdds-sh/src/Participant.cpp:18:
/usr/local/include/fastrtps/types/DynamicType.h:37:7: note:                 class eprosima::fastrtps::types::DynamicType
 class DynamicType
       ^~~~~~~~~~~
/code/src/fastdds-sh/src/Participant.cpp:278:42: error: expected primary-expression before '>' token
     return static_cast<const DynamicType*>(it->second.GetDynamicType().get());
                                          ^
/code/src/fastdds-sh/src/Participant.cpp:278:78: error: expected ')' before ';' token
     return static_cast<const DynamicType*>(it->second.GetDynamicType().get());
                                                                              ^
make[2]: *** [CMakeFiles/is-fastdds.dir/src/Participant.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/is-fastdds.dir/all] Error 2
make: *** [all] Error 2
```

As the error states, the `reference to 'DynamicType' is ambiguous` because `DynamicType` in the static cast resolves to two types: 
 - defined here: /usr/local/include/fastrtps/types/DynamicType.h
 - and defined here: /usr/local/include/fastrtps/types/TypeDescriptor.h

The breaking change was introduced in commit https://github.com/eProsima/Fast-DDS/commit/b084f8b1746e39954f53038bb634b5930ca21fa9 with the addition of the Content Filter. Hence using any version of Fast-DDS above v2.5.0 with the plugin will have this issue.
